### PR TITLE
32767 bug on outputs

### DIFF
--- a/AMP Log Analiser x1/AMP Log Analiser x1.vbproj
+++ b/AMP Log Analiser x1/AMP Log Analiser x1.vbproj
@@ -27,7 +27,7 @@
     <ProductName>APM Log File Analiser</ProductName>
     <PublisherName>TheBionicbone</PublisherName>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
-    <ApplicationRevision>4</ApplicationRevision>
+    <ApplicationRevision>6</ApplicationRevision>
     <ApplicationVersion>2.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/AMP Log Analiser x1/Classes/modFile_Handling.vb
+++ b/AMP Log Analiser x1/Classes/modFile_Handling.vb
@@ -197,7 +197,7 @@ Module modFile_Handling
             If DataArray(0) = "MSG" And DataArray(1) = "PX4:" Then APM_Version = DataArray(1) & " " & DataArray(2) & " " & DataArray(3) & " " & DataArray(4)
             If DataArray(0) = "RCOU" And MotorsDetectedForV3_2 = False Then
                 For N = 2 To 9
-                    If DataArray(N) > 0 Then APM_No_Motors = APM_No_Motors + 1
+                    If DataArray(N) > 0 And DataArray(N) < 32767 Then APM_No_Motors = APM_No_Motors + 1
                 Next
                 MotorsDetectedForV3_2 = True
             End If

--- a/AMP Log Analiser x1/Classes/modVariable_Declarations.vb
+++ b/AMP Log Analiser x1/Classes/modVariable_Declarations.vb
@@ -3,7 +3,7 @@ Imports System.Deployment.Application
 
 Module modVariable_Declarations
 
-    Public MyCurrentVersionNumber As String = "v2.0.0.4"          'Update on every released version.      'frmMainForm.BuildVers()                          'Update on every released version.
+    Public MyCurrentVersionNumber As String = "v2.0.0.5"          'Update on every released version.      'frmMainForm.BuildVers()                          'Update on every released version.
     Public CurrentPublishVersionNumber As String = ""               'frmMainForm.PublishedVers()                 'Now Detected by ApplicationDeployment.CurrentDeployment.CurrentVersion
 
     '### DEVELOPER TEMPORARY VARIABLES, TODO ###


### PR DESCRIPTION
Detect when unused motors are outputting as 32767 when calculating the
number of motors that are active.
