### PR TITLE
Fix Bug in ERROR checks

### DIFF
--- a/AMP Log Analiser x1/Classes/modERROR_Checks_v3_3.vb
+++ b/AMP Log Analiser x1/Classes/modERROR_Checks_v3_3.vb
@@ -2,7 +2,15 @@
     Public Sub ERROR_Checks_v3_3()
         'An Error value should have only 3 Pieces of data!
         If DataArray(0) = "ERR" Then
-            If IsNumeric(DataArray(1)) = False Or IsNothing(DataArray(3)) = False And (IsNumeric(DataArray(2) = False Or IsNothing(DataArray(2)) = False)) Then
+
+            ' Remove this old check from v3.2
+            ' I Believe that the new code will always give 3 data pieces now.
+            ' so we should be able to use the relilience checker
+            'If IsNumeric(DataArray(1)) = False Or IsNothing(DataArray(3)) = False And (IsNumeric(DataArray(2) = False Or IsNothing(DataArray(2)) = False)) Then
+
+
+            ' v3.3 - ERR, 109780635, 6, 1
+            If ReadFileResilienceCheck(3) <> True Then
                 Debug.Print("================================================================")
                 Debug.Print("== File Corruption Detected on Data Line " & DataLine & ", ERROR Checks v3.3 ignored! ==")
                 Debug.Print("================================================================")

--- a/AMP Log Analiser x1/Classes/modMainReadFile.vb
+++ b/AMP Log Analiser x1/Classes/modMainReadFile.vb
@@ -131,7 +131,6 @@ Module modMainReadFile
 
                         'Error Checks
                         If frmMainForm.chkboxErrors.Checked = True Then
-                            Call ERROR_Checks()
                             If DataArray(0) = "ERR" Then
                                 If (ReadFileVersion = 3.1 Or ReadFileVersion = 3.2) And ArduType = "APM:Copter" Then
                                     Call ERROR_Checks()


### PR DESCRIPTION
Was calling v3.2 version always
Removed old way of checking if all data was correct in favour of the
resilience checker as I think all ERROR data will always be there from
v3.3 onwards