### PR TITLE
Solo v1.2.0 support and Bug fixes

### DIFF
--- a/AMP Log Analiser x1/AMP Log Analiser x1.vbproj
+++ b/AMP Log Analiser x1/AMP Log Analiser x1.vbproj
@@ -153,6 +153,7 @@
     <Compile Include="Classes\modGPS_MainAnalysis.vb" />
     <Compile Include="Classes\modGPS_Functions.vb" />
     <Compile Include="Classes\modIMU_Checks.vb" />
+    <Compile Include="Classes\modIMU_Checks_Solo_v1_2_0.vb" />
     <Compile Include="Classes\modIMU_Checks_v3_1_v3_2.vb" />
     <Compile Include="Classes\modIMU_Checks_v3_3.vb" />
     <Compile Include="Classes\modMainReadFile.vb" />

--- a/AMP Log Analiser x1/Classes/modFile_Handling.vb
+++ b/AMP Log Analiser x1/Classes/modFile_Handling.vb
@@ -63,6 +63,16 @@ Module modFile_Handling
             FileDataSuitable = True
         End If
 
+        'Special Code for SOLO solo-1.2.0 to Force V3.2 code
+        If InStr(StrConv(ArduVersion, vbUpperCase), "SOLO-1.2.0") Then
+            WriteTextLog("Log file created by a Solo Copter (" & ArduVersion & ") - Forcing to v3.2 scanning")
+            ArduVersion = 3.2 : SoloFirmwareDetected_v3_2 = True ' Drives different IMU Code.
+            strTemp = "         Solo Copter Firmware Detected," & vbNewLine
+            strTemp = strTemp & "Compatibility may be limited at this time." & vbNewLine
+            MsgBox(strTemp, vbOKOnly, "Warning")
+        End If
+
+
         'Check the program is compatible with this log file version.
         If Ignore_LOG_Version = False Then
             If ArduType = "ArduCopter" Or ArduType = "APM:Copter" Then
@@ -276,11 +286,11 @@ Module modFile_Handling
             ' v3.3 - FMT, 129, 31, PARM, QNf, TimeUS,Name,Value
             If DataArray(0) = "PARM" Then
                 EndOfFMT = True
-                If (ReadFileVersion = 3.1 Or ReadFileVersion = 3.2) And ArduType = "APM:Copter" Then
-                    'Alter Old Version Data to meet v3.3 requirements
-                    DataArray(4) = DataArray(3) : DataArray(3) = DataArray(2)
+                If ReadFileVersion = 3.3 And ArduType = "APM:Copter" Then
+                    'Alter Data to meet v3.2 requirements by shifting it down one place.
+                    DataArray(1) = DataArray(2) : DataArray(2) = DataArray(3) : DataArray(3) = Nothing
                 End If
-                If IsNumeric(DataArray(3)) = False Or IsNothing(DataArray(4)) = False Then
+                If IsNumeric(DataArray(2)) = False Or IsNothing(DataArray(3)) = False Then
                     Debug.Print("================================================================")
                     Debug.Print("== File Corruption Detected on Data Line " & DataLine & ", PARM Check ignored! ==")
                     Debug.Print("================================================================")
@@ -296,8 +306,8 @@ Module modFile_Handling
                     End With
                 Else
                     If EndOfPARAM = False Then 'Handles log corruption where PARAMS from previous logs are added at the end.
-                        Param = DataArray(2)
-                        Value = Val(DataArray(3))
+                        Param = DataArray(1)
+                        Value = Val(DataArray(2))
 
                         'Write the parameter found to the Parameter List Box
                         frmParameters.lstboxParameters.Items.Add(Param & "  =  " & Value)

--- a/AMP Log Analiser x1/Classes/modIMU_Checks_Solo_v1_2_0.vb
+++ b/AMP Log Analiser x1/Classes/modIMU_Checks_Solo_v1_2_0.vb
@@ -1,0 +1,31 @@
+﻿Module modIMU_Checks_Solo_v1_2_0
+
+    Public Sub IMU_Checks_Solo_v1_2_0()
+
+        'This part only check the correct data structure of the data line
+        'and prepares the variables ready for the MainAnalysis which
+        'is called directly after by this code.
+
+        ' THIS CODE MUST ONLY BE CALLED AFTER THE DATA LINE HAS BEEN VALIDATED AS THE CORRECT TYPE !!!
+
+        'An IMU value should have only 7 pieces of numeric data!
+
+        'APM:Copter v3.2 - FMT, 131, 31, IMU, Iffffff, TimeMS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ
+        'APM:Copter v3.3 - FMT, 132, 49, IMU, QffffffIIfBB, TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt
+        '    Solo v1.2.0 - FMT, 131, 43, IMU, IffffffIIf, TimeMS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp
+
+        If ReadFileResilienceCheck(10) = True Then
+            'Debug.Print("IMU Data Detected...")
+            Log_IMU_TimeMS = Val(DataArray(1))
+            Log_IMU_GyrX = Val(DataArray(2))
+            Log_IMU_GyrY = Val(DataArray(3))
+            Log_IMU_GyrZ = Val(DataArray(4))
+            Log_IMU_AccX = Val(DataArray(5))
+            Log_IMU_AccY = Val(DataArray(6))
+            Log_IMU_AccZ = Val(DataArray(7))
+            Call IMU_MainAnalysis()
+        End If
+
+    End Sub
+
+End Module

--- a/AMP Log Analiser x1/Classes/modMainReadFile.vb
+++ b/AMP Log Analiser x1/Classes/modMainReadFile.vb
@@ -186,9 +186,13 @@ Module modMainReadFile
                         'IMU Checks - Vibration
                         If DataArray(0) = "IMU" Then
                             If ReadFileVersion = 3.1 Or ReadFileVersion = 3.2 Then
-                                Call IMU_Checks_v3_1_v3_2()
+                                If SoloFirmwareDetected_v3_2 = False Then
+                                    Call IMU_Checks_v3_1_v3_2()
+                                Else
+
+                                End If
                             Else
-                                Call IMU_Checks_v3_3()
+                                    Call IMU_Checks_v3_3()
                             End If
                         End If
 

--- a/AMP Log Analiser x1/Classes/modVariable_Declarations.vb
+++ b/AMP Log Analiser x1/Classes/modVariable_Declarations.vb
@@ -77,6 +77,7 @@ Module modVariable_Declarations
     '                                                           ' or for v3.2 a count of the values > 0  in the RCOUT dataline.
     Public Hardware As String = ""                              ' Holds the type of hardware used.
     Public Pixhawk_Serial_Number As String                      ' Holds the PixHawk Serial Number.
+    Public SoloFirmwareDetected_v3_2 As Boolean = False         ' True if ArduVersion returned with the name "solo" in it and was replaced with v3.2
 
     'Declare the Parameter Variables
     Public Param As String = ""                                 ' Parameter read from the Log.

--- a/AMP Log Analiser x1/Classes/modVariable_Initialisation.vb
+++ b/AMP Log Analiser x1/Classes/modVariable_Initialisation.vb
@@ -240,6 +240,7 @@
         APM_No_Motors = 0                               'Holds the number of Motors, determined from the FMT for MOT.
         Hardware = ""                                   'Holds the type of hardware used.
         Pixhawk_Serial_Number = ""                      'Holds the PixHawk Serial Number.
+        SoloFirmwareDetected_v3_2 = False               ' True if ArduVersion returned with the name "solo" in it and was replaced with v3.2
 
         'Decalre the IMU Variables
         Log_IMU_TimeMS = 0                              'Holds the current IMU Time in ms that the last reading was taken.

--- a/AMP Log Analiser x1/obj/Debug/AMP Log Analiser x1.vbproj.FileListAbsolute.txt
+++ b/AMP Log Analiser x1/obj/Debug/AMP Log Analiser x1.vbproj.FileListAbsolute.txt
@@ -56,7 +56,6 @@ C:\Users\Kevin\Documents\GitHub\APM_Analyzer\APM_Log_File_Analyzer\AMP Log Anali
 C:\Users\Kevin\Documents\GitHub\APM_Analyzer\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.TrustInfo.xml
 C:\Users\Kevin\Documents\GitHub\APM_Analyzer\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.exe.manifest
 C:\Users\Kevin\Documents\GitHub\APM_Analyzer\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.application
-C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\AMP Log Analiser x1.vbprojResolveAssemblyReference.cache
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APMLogFileAnaliser.frmMainForm.resources
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APMLogFileAnaliser.frmUpdate.resources
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APMLogFileAnaliser.frmHelp.resources
@@ -84,3 +83,4 @@ C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\De
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.application
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.exe
 C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\APM Log File Analiser.pdb
+C:\Users\Kevin\Documents\GitHub\APM_Log_File_Analyzer\AMP Log Analiser x1\obj\Debug\AMP Log Analiser x1.vbprojResolveAssemblyReference.cache


### PR DESCRIPTION
Solo uses the same format as v3.2 except for the IMU data which just has
a few more fields.
Some bugs were introduced while adding support for v3.3 that made v3.2
PARMs fail.