### PR TITLE
Remove Motor Testing from Analysis

### DIFF
--- a/AMP Log Analiser x1/Classes/modDisplay_Functions.vb
+++ b/AMP Log Analiser x1/Classes/modDisplay_Functions.vb
@@ -272,14 +272,14 @@ Module modDisplay_Functions
             If APM_No_Motors = 6 Then APM_Frame_Name += " (Hexa)"
             If APM_Frame_Name <> "" Then WriteTextLog("   Frame Type: " & APM_Frame_Name)
             If APM_No_Motors <> 0 Then
-                WriteTextLog("      Testing: Motor Detection Analysis Results:-")
-                WriteTextLog("      Testing: ┌-----------------------------------------┐")
-                WriteTextLog("      Testing: |  Ch1 = " & Format(Log_RCOU_Ch1, "000") & "% |  Ch2 = " & Format(Log_RCOU_Ch2, "000") & "% |  Ch3 = " & Format(Log_RCOU_Ch3, "000") & "% |")
-                WriteTextLog("      Testing: |  Ch4 = " & Format(Log_RCOU_Ch4, "000") & "% |  Ch5 = " & Format(Log_RCOU_Ch5, "000") & "% |  Ch6 = " & Format(Log_RCOU_Ch6, "000") & "% |")
-                WriteTextLog("      Testing: |  Ch7 = " & Format(Log_RCOU_Ch7, "000") & "% |  Ch8 = " & Format(Log_RCOU_Ch8, "000") & "% |  Ch9 = " & Format(Log_RCOU_Ch9, "000") & "% |")
-                WriteTextLog("      Testing: | Ch10 = " & Format(Log_RCOU_Ch10, "000") & "% | Ch11 = " & Format(Log_RCOU_Ch11, "000") & "% | Ch12 = " & Format(Log_RCOU_Ch12, "000") & "% |")
-                WriteTextLog("      Testing: └-----------------------------------------┘")
-                WriteTextLog("      Testing: Sampled " & MotorDetec_Counter_RCOU & " Channel Output Readings")
+                'WriteTextLog("      Testing: Motor Detection Analysis Results:-")
+                'WriteTextLog("      Testing: ┌-----------------------------------------┐")
+                'WriteTextLog("      Testing: |  Ch1 = " & Format(Log_RCOU_Ch1, "000") & "% |  Ch2 = " & Format(Log_RCOU_Ch2, "000") & "% |  Ch3 = " & Format(Log_RCOU_Ch3, "000") & "% |")
+                'WriteTextLog("      Testing: |  Ch4 = " & Format(Log_RCOU_Ch4, "000") & "% |  Ch5 = " & Format(Log_RCOU_Ch5, "000") & "% |  Ch6 = " & Format(Log_RCOU_Ch6, "000") & "% |")
+                'WriteTextLog("      Testing: |  Ch7 = " & Format(Log_RCOU_Ch7, "000") & "% |  Ch8 = " & Format(Log_RCOU_Ch8, "000") & "% |  Ch9 = " & Format(Log_RCOU_Ch9, "000") & "% |")
+                'WriteTextLog("      Testing: | Ch10 = " & Format(Log_RCOU_Ch10, "000") & "% | Ch11 = " & Format(Log_RCOU_Ch11, "000") & "% | Ch12 = " & Format(Log_RCOU_Ch12, "000") & "% |")
+                'WriteTextLog("      Testing: └-----------------------------------------┘")
+                'WriteTextLog("      Testing: Sampled " & MotorDetec_Counter_RCOU & " Channel Output Readings")
                 WriteTextLog("   No. Motors: " & APM_No_Motors)
             End If
             WriteTextLog("")


### PR DESCRIPTION
Removes the Testing Code at the top of the text based analysis that was
introduced during the motor testing.